### PR TITLE
Add Github Actions for CI/CD Pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build (bgda-vita w/ VitaSDK SoftFP)
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Pull VitaSDK SoftFP Docker image
+        run: docker pull vitasdk/vitasdk-softfp:latest
+
+      - name: Build in VitaSDK container
+        run: |
+          docker run --platform linux/amd64 --rm \
+            -v "$GITHUB_WORKSPACE:/vita-dev/bgda-vita" \
+            -w /vita-dev/bgda-vita \
+            vitasdk/vitasdk-softfp:latest \
+            /bin/bash -c "
+              set -e
+              git config --global --add safe.directory '*'
+              git submodule update --init --recursive
+              chmod +x extras/scripts/build_and_run.sh
+              extras/scripts/build_and_run.sh
+            "
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vita-build
+          path: |
+            build/*.vpk
+            build/*.velf
+          if-no-files-found: error

--- a/extras/scripts/build_and_run.sh
+++ b/extras/scripts/build_and_run.sh
@@ -1,10 +1,23 @@
 cd /vita-dev/bgda-vita/lib/vitaGL
-git apply --check /vita-dev/bgda-vita/vitaGL.patch
+
+if git apply --reverse --check /vita-dev/bgda-vita/vitaGL.patch; then
+  echo "[vitaGL] Patch already applied"
+else
+  echo "[vitaGL] Applying vitaGL patch"
+  git apply /vita-dev/bgda-vita/vitaGL.patch
+fi
+
 make clean
 make -j64 HAVE_UNFLIPPED_FBOS=0 UNPURE_TEXTURES=1 HAVE_WRAPPED_ALLOCATORS=0 HAVE_PROFILING=0 SOFTFP_ABI=1 LOG_ERRORS=0 HAVE_GLSL_SUPPORT=1 USE_SCRATCH_MEMORY=0 CIRCULAR_VERTEX_POOL=2 HAVE_SHARK_LOG=0 NO_DEBUG=0 HAVE_DEBUGGER=0 SAFE_UNIFORMS=1 STORE_DEPTH_STENCIL=0 HAVE_TEXTURE_CACHE=0 DRAW_SPEEDHACK=2 INDICES_SPEEDHACK=1 INDICES_DRAW_SPEEDHACK=1 HAVE_CPU_TRACER=0 BUFFERS_SPEEDHACK=0 DEBUG_GLSL_TRANSLATOR=0 HAVE_DEVKIT=0 DEPTH_STENCIL_HACK=0 HAVE_RAZOR=0 install 
 mkdir -p /vita-dev/bgda-vita/build
 cd /vita-dev/bgda-vita/build
 cmake ..
 make -j64 clean
-make -j64 send
-#make
+# Only run 'make send' if nc is available
+if command -v nc >/dev/null 2>&1; then
+    echo "nc found — running 'make send'"
+    make -j64 send
+else
+    echo "nc not found — skipping 'make send'"
+    make -j64
+fi


### PR DESCRIPTION
Added a build pipeline to match the recently added build instructions. This serves as a sanity check to make sure future changes don’t break the build process.

Note: I guess the --check flag in git apply was silently failing due to the whitespace issues in the .patch file. I added a better check and more verbose output. I also don't have `make send` setup correctly so I added a check to just build without sending if `netcat` is not installed.